### PR TITLE
Logging errors in console instead of throwing

### DIFF
--- a/lib/program.js
+++ b/lib/program.js
@@ -82,14 +82,14 @@ var optArgProcess = function(oStr, opt, cmd, res, incrArrCountFn, userInputArg) 
       argSet(opt.defaultArg);
     }
     else {
-      throw `Argument expected for option: ${oStr}.`;
+      console.error(`Argument expected for option: ${oStr}.`);
     }
   }
   else if(opt.defaultArg) {
     argSet(opt.defaultArg);
   }
   else {
-    throw `Argument expected for option: ${oStr}.`;
+    console.error(`Argument expected for option: ${oStr}.`);
   }
 }
 
@@ -126,8 +126,8 @@ Program.prototype.parseSync = function(arr) {
         }
       }
       else {
-        if(cmd) throw `Unrecognized option ${item} for command ${res.cmd}.`;
-        else throw `Unrecognized global option: ${item}.`;
+        if(cmd) console.error(`Unrecognized option ${item} for command ${res.cmd}.`);
+        else console.error(`Unrecognized global option: ${item}.`);
       }
     }
     else if(item.startsWith('-')) { // short option
@@ -150,8 +150,8 @@ Program.prototype.parseSync = function(arr) {
           }
         }
         else {
-          if(cmd) throw `Unrecognized option ${oStr} for command ${res.cmd}.`;
-          else throw `Unrecognized global option: ${oStr}.`;
+          if(cmd) console.error(`Unrecognized option ${oStr} for command ${res.cmd}.`);
+          else console.error(`Unrecognized global option: ${oStr}.`);
         }
       }
     }
@@ -162,7 +162,7 @@ Program.prototype.parseSync = function(arr) {
           res.cmd = item;
         }
         else {
-          throw `Unrecognized command: ${item}.`;
+          console.error(`Unrecognized command: ${item}.`);
         }
       }
       else {


### PR DESCRIPTION
Throwing errors prints stacktrace:
<img width="632" alt="screen shot 2016-04-27 at 1 37 35 am" src="https://cloud.githubusercontent.com/assets/8026027/14833382/a5675d76-0c1c-11e6-920d-55a127dc9100.png">

After this fix, it logs errors and also prints the usage.
<img width="525" alt="screen shot 2016-04-27 at 2 06 55 am" src="https://cloud.githubusercontent.com/assets/8026027/14833407/c65d3dde-0c1c-11e6-881a-aa732881878e.png">
